### PR TITLE
Fix: Prevent form from refreshing and display error messages correction

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -193,7 +193,7 @@
                     exclusive offers.
                 </p>
                 <form action="#">
-                    <input type="text" placeholder="Your email" required>
+                    <input type="email" placeholder="Your email" required>
                     <button type="submit">Subscribe</button>
                 </form>
             </div>

--- a/dine-in.html
+++ b/dine-in.html
@@ -240,7 +240,7 @@
                     exclusive offers.
                 </p>
                 <form action="#">
-                    <input type="text" placeholder="Your email" required>
+                    <input type="email" placeholder="Your email" required>
                     <button type="submit">Subscribe</button>
                 </form>
             </div>

--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
                     exclusive offers.
                 </p>
                 <form action="#">
-                    <input type="text" placeholder="Your email" required>
+                    <input type="email" placeholder="Your email" required>
                     <button type="submit">Subscribe</button>
                 </form>
             </div>

--- a/script/form.js
+++ b/script/form.js
@@ -1,3 +1,4 @@
+// Contact form validation
 const contactForm = document.getElementById("contact-form");
 const firstname = document.getElementById("fname");
 const lastname = document.getElementById("lname");
@@ -7,46 +8,56 @@ const message = document.getElementById("message");
 const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const phoneRegex = /^[0-9]{10}$/;
 
-contactForm.addEventListener("submit", (e)=> {
+contactForm.addEventListener("submit", (e) => {
     e.preventDefault();
     
+    let valid = true;  // Assume form is valid until proven otherwise
+
+    clearError(firstname);
+    clearError(lastname);
+    clearError(email);
+    clearError(phone);
+    clearError(message);
+
     if (firstname.value.trim() === "") {
         setError(firstname, "First name is required!");
+        valid = false;
     }
     if (lastname.value.trim() === "") {
         setError(lastname, "Last name is required!");
+        valid = false;
     }
     if (email.value.trim() === "") {
         setError(email, "Email is required!");
-    }
-    else if (!emailRegex.test(email.value.trim())){
+        valid = false;
+    } 
+    else if (!emailRegex.test(email.value.trim())) {
         setError(email, "Invalid email format!");
+        valid = false;
     }
     if (phone.value.trim() === "") {
         setError(phone, "Phone number is required!");
-    }
-    else if (!phoneRegex.test(phone.value.trim())){
+        valid = false;
+    } 
+    else if (!phoneRegex.test(phone.value.trim())) {
         setError(phone, "Contact number must have exactly 10 digits");
+        valid = false;
     }
     if (message.value.trim() === "") {
         setError(message, "Message is required!");
+        valid = false;
+    }
+
+    // If all fields are valid, submit the form
+    if (valid) {
+        contactForm.submit();  // Only submit if everything is valid
     }
 });
 
-// Newsletter section scripts
-const newsletterForm = document.getElementById("news-letter");
-const newsletterEmail = document.getElementById("newsletter-email");
-
-newsletterForm.addEventListener("submit", (e)=> {
-    e.preventDefault();
-
-    if (newsletterEmail.value.trim() === "") {
-        setError(newsletterEmail, "Email is required!");
-    }
-    else if (!emailRegex.test(newsletterEmail.value.trim())) {
-        setError(newsletterEmail, "Invalid email format!");
-    }
-});
+function clearError(field) {
+    const error = field.parentElement.querySelector("small");
+    error.textContent = ""; // Clear the error message
+}
 
 function setError(field, errorMessage) {
     const error = field.parentElement.querySelector("small");


### PR DESCRIPTION
what is this PR about
"Newsletter Email Section Lacks Validation" #169

- Added clearError and setError logic to handle field-specific error messages.
- Used preventDefault() to stop page from reloading on form submission.
- Added validation for first name, last name, email, phone, and message fields.
- Ensured proper display of error messages without jumping to the top of the page.
- 
![image](https://github.com/user-attachments/assets/4ae078bc-6417-4168-95f
![Screenshot 2024-10-05 224019](https://github.com/user-attachments/assets/f3878de4-741b-4c58-8202-5b5cc3775eab)
9-0293a8b5b54e)
