### PR TITLE
I removed the pre-loader option because it shows infinite loading, and…

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
 
 <body>
     <!-- Preloader -->
-    <div id="preloader">
+    <!-- <div id="preloader">
         <img src="images/logo.png" alt="Preloader" class="preloader-icon">
         <p class="loading-text">Loading...</p>
-    </div>
+    </div> -->
 
         <!-- scroll progress -->
         <div class="scroll-progress"></div>
@@ -518,7 +518,7 @@
 
     <!-- copyright -->
     <div class="copyright">
-        &copy; 2024 by <span>DharshiB</span> | All Rights Deserved
+        &copy; 2024 by <span>DharshiB</span> | All Rights Reserved
     </div>
 
     </div>


### PR DESCRIPTION
… I also fixed typos in the copyright section.
<img width="592" alt="Screenshot 2024-10-10 at 10 40 18 PM" src="https://github.com/user-attachments/assets/fe75e6ce-8026-4caa-ba17-6108ade6ac66">
In this you write the deserved instead of the reserved. 
And I also remove the pre loader because it shows the infinite loading.