### PR TITLE
#479 fixed pics border-radius

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -489,19 +489,19 @@ h3 {
 
 }
 .grid-box:nth-of-type(1){
-    border-radius: 25px;
+    border-radius: 25px 0px 0px 0px;
     background-image: url("../images/hero-grid1.jpg");
 }
 .grid-box:nth-of-type(2){
-    border-radius: 10px 15px 25px 0;
+    border-radius: 0px 25px 0px 0;
     background-image: url("../images/hero-grid2.jpg");
 }
 .grid-box:nth-of-type(3){
-    border-radius: 0 0 0 35px;
+    border-radius: 0px 0px 0px 25px;
     background-image: url("../images/hero-grid3.jpg");
 }
 .grid-box:nth-of-type(4){
-    border-radius: 0 15px 0 15px;
+    border-radius: 0px 0px 25px 0px;
     background-image: url("../images/hero-grid4.jpg");
 }
 


### PR DESCRIPTION
# 🚀 Pull Request

## Description

I have changed the border-radius of the pics in home page to give them a good look. Alos now they are evenly alligned with correct border-radius and sizes.

- Fixes #479 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot of final output/video
<img width="670" alt="Screenshot 2024-10-13 at 8 00 20 PM" src="https://github.com/user-attachments/assets/73a60374-f895-4523-9eb1-8cbca451dcf2">
