### PR TITLE
[FIXED] [Bug]: Popup on landing page getting cut #865

### DIFF
--- a/styles/home.css
+++ b/styles/home.css
@@ -512,7 +512,7 @@
     border-radius: 10px;
     width: 100%;
     max-width: 800px;
-    height: 450px;
+    height: 520px;
     overflow: hidden;
     position: relative;
     box-shadow: 0 0 15px whitesmoke;


### PR DESCRIPTION
# 🚀 Pull Request

## Description

The height of the popup was not upto the adequate amount required, resulting in some of the content getting cut. I fixed that by increasing the height of the popup to solve the issue.

- Fixes #865 
- Closes #865 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Screenshot of final output/video
Before:
<img width="831" alt="Screenshot 2024-10-23 at 8 23 20 PM" src="https://github.com/user-attachments/assets/5cfaecaa-a7fb-4e7f-9c1b-0aeaac00a2ac">
After:
<img width="831" alt="Screenshot 2024-10-23 at 8 23 09 PM" src="https://github.com/user-attachments/assets/b0d49f6b-6edc-4539-bbc4-ab2ae1f19706">
