### PR TITLE
I added link of favicon in some pages

### DIFF
--- a/catering.html
+++ b/catering.html
@@ -12,6 +12,8 @@
     <link rel="stylesheet" href="styles/mediaQueries.css">
     <link rel="stylesheet" href="styles/swiper-bundle.min.css">
     <link rel="stylesheet" href="styles/topscrollindicator.css">
+    <!-- Link to add favicon  -->
+    <link rel="icon" href="./images/logo.png" type="image/png">
     
     <link rel="stylesheet" href="styles/cursor.css">
     <link rel="stylesheet" href="styles/delivery-catering.css">

--- a/contributor.html
+++ b/contributor.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="styles/cursor.css">
     <link rel="stylesheet" href="styles/styles.css">
     <link rel="stylesheet" href="styles/topscrollindicator.css">
+    <!-- Link to add favicon  -->
+    <link rel="icon" href="./images/logo.png" type="image/png">
 
     <link
       rel="stylesheet"

--- a/privacy.html
+++ b/privacy.html
@@ -10,6 +10,8 @@
     <link rel="stylesheet" href="styles/styles.css">
     <link rel="stylesheet" href="./styles/mediaQueries.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <!-- Link to add favicon  -->
+    <link rel="icon" href="./images/logo.png" type="image/png">
 
 </head>
 


### PR DESCRIPTION
Link of favicon is added in  pages such as contributors, privacy policy, catering which was earlier not visible.

# 🚀 Pull Request

## Description

Added favicon link to enhance the project's visibility and user experience in browser tabs as part of GSSoC 2024.

- Fixes #823
- Closes #(issue Number)

## Type of Change

 UI Improvement - Since adding a favicon is a minor but visible improvement to the user interface.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot of final output/video
1. "CONTRIBUTORS PAGE"
![sol1](https://github.com/user-attachments/assets/27948a99-1c32-4c8e-867a-58f8d046bbbe)
2.  "CATERING PAGE"
![sol2](https://github.com/user-attachments/assets/8fae6e9e-3da5-47c6-868b-bec1d7676491)
3. "PRIVACY POLICY PAGE"
![sol3](https://github.com/user-attachments/assets/66b5e39a-defe-46cf-9642-0973406a0e50)

