### PR TITLE
Gallery menu removed from gallery's navbar

### DIFF
--- a/gallary.html
+++ b/gallary.html
@@ -79,7 +79,7 @@
             <a href="./dine-in.html" class="link">Dine In</a>
             <a href="./catering.html" class="link">Catering</a>
           
-            <a href="./gallery.html" class="link" style="text-decoration: underline;">Gallery</a>
+           
             
     <!-- Cart -->
     <div class="cart">


### PR DESCRIPTION
# 🚀 Pull Request

## Description
Gallery menu removed from gallery's navbar

- Fixes #831 
- Closes #831 

## Screenshot of final output
![image](https://github.com/user-attachments/assets/9aeb47a0-1ef4-44fe-89a2-438df58048da)
