### PR TITLE
Bugfix: Cleaned Up HTML Structure by Removing Extra Closing </div> in terms&condition.html

### DIFF
--- a/terms&condition.html
+++ b/terms&condition.html
@@ -272,8 +272,6 @@
         &copy; 2024 by <span>DharshiB</span> | All Rights Reserved
     </div>
 
-    </div>
-
     <!-- Toaster -->
     <div id="toast-container" class="toast-container"></div>
 


### PR DESCRIPTION
# 🚀 Pull Request

### Description

**Issue**: An extra closing `<div>` tag was found in `terms&condition.html` at line 275. While this does not visibly affect the page layout, it could lead to potential issues in HTML structure and maintainability.

**Fix**: Removed the extra `<div>` tag at line 275 to ensure proper HTML structure.

### Summary of Changes
- **File**: `terms&condition.html`
- **Change**: Removed the extra closing `<div>` tag at line 275.

- Fixes #934 
- Closes #934 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot of changes

Before
![image](https://github.com/user-attachments/assets/329679ce-5075-45a8-be37-dccd8a5bb004)

After
![WhatsApp Image 2024-10-28 at 19 24 40_a0195daa](https://github.com/user-attachments/assets/4d8fffbd-31b8-4e54-aa2f-57b40329157a)


**Note**: There is no change in the overall appearance of the site.
