### PR TITLE
Fix Newsletter Popup Reappearance After User Dismissal

### DIFF
--- a/script/popup.js
+++ b/script/popup.js
@@ -23,5 +23,10 @@
     document.querySelector('.no-thanks').addEventListener('click', function(event) {
       event.preventDefault();
       document.getElementById('popup').style.display = 'none';
+      localStorage.setItem("noThanksClicked", "true");
     });
+
+    if (localStorage.getItem("noThanksClicked") === "true") {
+      document.getElementById('popup').style.visibility = 'hidden';
+    }
     


### PR DESCRIPTION
# Title: Fix Newsletter Popup Reappearance After User Dismissal

## Description

Fix #1106   

This PR resolves the issue of the newsletter popup reappearing after clicking **"No Thanks"** by implementing a dismissal flag in cookies/local storage. The popup now checks this flag before displaying, enhancing the user experience by preventing unnecessary prompts.

@DharshiBalasubramaniyam  
Pls assign me this, Give me label, level.