### PR TITLE
Hiding Cursor on Mobile View

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -867,4 +867,8 @@ h3 {
     /* so that it stays on top of all other elements */
 }
 
-
+@media (max-width: 768px) {
+    .circle {
+        display: none;
+    }
+}


### PR DESCRIPTION
### Hiding Cursor on Mobile View

Fix #1105 

This PR implements a solution to hide the `circle` on screens 768 pixels wide or smaller. The visibility is controlled using CSS media queries to enhance the mobile user experience.

@DharshiBalasubramaniyam
Pls give me labels like gssoc-extd, level and assign me this issue.